### PR TITLE
fixed midi event filtering

### DIFF
--- a/webaudio-controls.html
+++ b/webaudio-controls.html
@@ -2113,19 +2113,23 @@
       		externalListener(event);
     	});
 
-    	// switches may receive pressure pad events too
+  		//console.log("event[0] =" + event.data[0]);
+  		//console.log("(event.data[0]&0xf0)!=0xb0) = " + ((event.data[0]&0xf0)!=0xb0));
+
+
+  		// for webaudiocontrols sliders and knobs, we limit to 
+  		// cc midi events
+  		if(((event.data [0] & 0xf0) == 0xf0) || ((event.data [0] & 0xf0) == 0xb0 && event.data [1]>= 120)) {
+  			alert("filtered");
+  			return;
+  		}
+      		
+
     	for (var i = 0; i <switches.length; i++){
       		switches[i].processMidiEvent(event);
     	}
 
-  		// for webaudiocontrols sliders and knobs, we limit to 
-  		// cc midi events
-  		//console.log("event[0] =" + event.data[0]);
-  		//console.log("(event.data[0]&0xf0)!=0xb0) = " + ((event.data[0]&0xf0)!=0xb0));
-  		if((event.data[0]&0xf0)!=0xb0)
-      		return;
-
-    	for (var i = 0; i <knobs.length; i++){
+   		for (var i = 0; i <knobs.length; i++){
       		knobs[i].processMidiEvent(event);
     	}
     	for (var i = 0; i <sliders.length; i++){


### PR DESCRIPTION
Ok, it should be good know about midi event filtering. Check at the end of webaudio-controls.html

I'll try to add a "getCurrentConfigJSON()/restoreConfig(jsonConfig)" methods, for exporting/importing all midi mappings in JSON.