### PR TITLE
Update: 'Cannot read property 'focus' of undefined' error

### DIFF
--- a/webaudio-controls.html
+++ b/webaudio-controls.html
@@ -1897,7 +1897,7 @@
 				if(this.enable) {
 					this.press=1;
 					this.pointermove(e);
-					this.childNodes[1].focus();
+					if(this.hasChildNodes() && this.childNodes.length>0) this.childNodes[1].focus();
 				}
 				e.preventDefault();
 			},


### PR DESCRIPTION
Update: 'Cannot read property 'focus' of undefined' error prevention by checking the size of this.childNodes.