### PR TITLE
Add "enable" attr support for wheel events

### DIFF
--- a/webaudio-controls.js
+++ b/webaudio-controls.js
@@ -451,6 +451,8 @@ webaudio-knob{
         this.sendEvent("input"),this.sendEvent("change");
     }
     wheel(e) {
+      if (!this.enable)
+        return;
       let delta=(this.max-this.min)*0.01;
       delta=e.deltaY>0?-delta:delta;
       if(!e.shiftKey)


### PR DESCRIPTION
Check "enable" attribute when dealing with mousewheel events on knobs. If a knob is not enabled, it should not react to wheel events.